### PR TITLE
Fixed bug causing consecutive runs to re-run the initially failing tests again

### DIFF
--- a/dist/junit-xml.js
+++ b/dist/junit-xml.js
@@ -59,16 +59,8 @@ function processResults(filePattern, testAttempt) {
     var resultDir = _path2['default'].dirname(resolvedPath);
     var resultFileName = _path2['default'].basename(resolvedPath);
     var processedResultsFile = _path2['default'].resolve(resultDir, 'flake-' + resultFileName);
-
-    var fileExists = _fs2['default'].existsSync(processedResultsFile);
-    if (fileExists) {
-      console.log(resolvedPath + ' already read since ' + processedResultsFile + ' exists\n');
-      // For sanity of results, we need to process it instead
-      resolvedPath = processedResultsFile;
-    } else {
-      console.log('Parsing file ', resolvedPath, '\n');
-    }
     var fileContents = _fs2['default'].readFileSync(resolvedPath);
+
     try {
       (0, _xml2js.parseString)(fileContents, function (err, result) {
         if (err) {
@@ -84,7 +76,7 @@ function processResults(filePattern, testAttempt) {
             return !!caze.failure;
           }).value();
 
-          suite.testcase = cases[1];
+          suite.testcase = cases[0];
           var cazeNames = cases[0].map(function (caze) {
             return caze.$.name;
           });

--- a/src/junit-xml.js
+++ b/src/junit-xml.js
@@ -34,16 +34,8 @@ export function processResults (filePattern, testAttempt) {
     var resultDir = path.dirname(resolvedPath)
     var resultFileName = path.basename(resolvedPath)
     var processedResultsFile = path.resolve(resultDir, `flake-${resultFileName}`)
-
-    var fileExists = fs.existsSync(processedResultsFile)
-    if (fileExists) {
-      console.log(`${resolvedPath} already read since ${processedResultsFile} exists\n`)
-      // For sanity of results, we need to process it instead
-      resolvedPath = processedResultsFile
-    } else {
-      console.log('Parsing file ', resolvedPath, '\n')
-    }
     var fileContents = fs.readFileSync(resolvedPath)
+
     try {
       parseXml(fileContents, (err, result) => {
         if (err) {
@@ -60,7 +52,7 @@ export function processResults (filePattern, testAttempt) {
             .partition(caze => !!caze.failure)
             .value()
 
-          suite.testcase = cases[1]
+          suite.testcase = cases[0]
           let cazeNames = cases[0].map(caze => caze.$.name)
           if (cazeNames) {
             specNames.push(...cazeNames)


### PR DESCRIPTION
After adding protractor-junit-flake to one of my test packs I noticed a bug that would cause consecutive runs to run the same failed tests from the first run instead of the failures from the last attempt.

Example run with 4 it blocks:

- First run 3 fail
- re-running only the 3 failed tests
- out of those 3, 2 pass.
- re-running the 3 failed tests (should only be the one failing test from before, but it re-runs the failing tests from the first run)

This is the describe block used for testing this behaviour:
```
describe('Testing protractor flake', () => {

  it('should fail sometimes test 1', () => {
    expect(Math.floor(Math.random() * 2)).toBe(1);
  });

  it('should fail sometimes test 2', () => {
    expect(Math.floor(Math.random() * 2)).toBe(1);
  });

  it('should fail sometimes test 3', () => {
    expect(Math.floor(Math.random() * 2)).toBe(1);
  });

  it('should fail sometimes test 4', () => {
    expect(Math.floor(Math.random() * 2)).toBe(1);
  });
```

This issue was only noticeable on the third run, if the tests only got re-run once the bug wasn't showing.
